### PR TITLE
Use "et al." in Dutch

### DIFF
--- a/apa-nl-surf.csl
+++ b/apa-nl-surf.csl
@@ -32,6 +32,11 @@
       <term name="from">de</term>
     </terms>
   </locale>
+  <locale xml:lang="nl">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">


### PR DESCRIPTION
Although the default translation "e.a." is linguistically correct, we use the Latin abbreviation.