### PR TITLE
Show full date for magazines

### DIFF
--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -166,7 +166,7 @@
       <if type="book chapter paper-conference motion_picture" match="any">
         <date variable="issued" form="numeric" date-parts="year"/>
       </if>
-      <else-if type="article-journal article-magazine" match="any">
+      <else-if type="article-journal" match="any">
         <date variable="issued" form="text" date-parts="year-month"/>
       </else-if>
       <else-if type="speech" match="none">


### PR DESCRIPTION
If the source is of type `article-magazine`, we do show the full date if it provided.